### PR TITLE
[Fix] - Markdown convention is to have a blank line after section headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Contributing to the Quix Documentation
+
 You want to help improve our documentation? Fantastic! Here are a few guidelines to help you get started.
 
 ## Reporting Bugs and Requesting Enhancements
+
 If you spot a mistake or see room for improvement in any of the Quix docs, please let us know! To create an issue, follow these steps:
 
 1. Open the [Github issues](https://github.com/quixai/quix-docs/issues) page for the Quix documentation repository.
@@ -12,9 +14,11 @@ We'll try to respond within a couple of working days.
 
 
 ## How Do I Submit a Good Docs Issue?
+
 Make sure your title is clear and descriptive. For any problem or enhancement, describe it in full, including any expected results and how they differ from the real results. The more descriptive your issue is, the quicker we'll be able to resolve your issue.
 
 ## Contributing Changes
+
 If you want to fix an issue yourself, go ahead! We welcome edits. For small changes, like typos and minor clarification, you can do an online edits in the GitHub Editor. 
 
 If you want to do more, or if you prefer to work offline, you can fork this repo, add your changes locally and then push to your fork. After that, you can create a pull request to merge your changes into the original docs repository.
@@ -22,6 +26,7 @@ If you want to do more, or if you prefer to work offline, you can fork this repo
 `Please create forks or branches from the 'dev' branch.`
 
 ## Online Edits in the GitHub Editor
+
 If you want to make a change, you can do it right on GitHub. Just follow these steps:
 
 1. Open the page you want to change click the edit button edit button.
@@ -33,6 +38,7 @@ This will open the relevant page in GitHub
 `Remember to create forks or branches from the 'dev' branch.`
 
 ## PR Reviews
+
 A member of our team will review your pull request. We might give feedback and suggestions for how you could improve the pull request, which is the same process we use when reviewing each others work internally. We'll try to respond within a couple of working days, but feedback can sometimes take longer. We appreciate all your feedback and contributions.
 
 ## Contact


### PR DESCRIPTION
## Description

A small PR to test command-line access to this GitHub repo.

Markdown convention is to have a blank line after a section heading. This PR edits the README to have a blank line after each section heading. Although this PR was primarily a test, it provides a useful little fix.

See [this guide](https://www.markdownguide.org/basic-syntax/#heading-best-practices) for more details.

## Review

This does not affect the generated docs, just the README for the repo, so just check the diff to review. 