### PR TITLE
[fix] - remove link to contrib from toc

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,8 +80,6 @@ nav:
       - 'Reading data': 'apis/streaming-reader-api/reading-data.md'
       - 'Subscription & Event reference': 'apis/streaming-reader-api/subscriptions.md'
     - 'Portal API': 'apis/portal-api.md'
-  - Contributing:
-      - 'Contributing to the docs': 'contributing.html'
 
 plugins:
   - search:


### PR DESCRIPTION
## Description

We have a `CONTRIBUTING.md` in the root of the repo, I don't think we need it in the main TOC.

This also fixes the broken nav, as currently the TOC entry points to a file that no longer exists.

Note: Also, landing page has a box for contribution.