### PR TITLE
Add section on doc releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This repository is the source content for the Quix documentation that is publish
 
 To get a free Quix account, [sign up](https://portal.platform.quix.ai/self-sign-up).
 
+## Doc releases
+
+You can find detailed information on doc releases in the [docs repo Wiki page](https://github.com/quixio/quix-docs/wiki/Docs-Releases).
+
 ## Contributing
 
 If you would like to contribute to the docs, there are two main ways:
@@ -42,6 +46,6 @@ If you are part of the Quix technical writing team, or you contribute frequently
 
 ## Getting in touch
 
-If you need any help, please sign up to the [Quix community forum](https://forum.quix.io/){target=_blank}.
+If you need any help, please sign up to the [Quix community forum](https://forum.quix.io/).
 
 Thanks!

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This repository is the source content for the Quix documentation that is publish
 
 To get a free Quix account, [sign up](https://portal.platform.quix.ai/self-sign-up).
 
-## Doc releases
+## Docs releases
 
-You can find detailed information on doc releases in the [docs repo Wiki page](https://github.com/quixio/quix-docs/wiki/Docs-Releases).
+You can find detailed information on docs releases in the [docs repo Wiki page](https://github.com/quixio/quix-docs/wiki/Docs-Releases).
 
 ## Contributing
 


### PR DESCRIPTION
## Description

* Adds a short section on docs releases so people know about the Wiki page
* Removes a `{target=_blank}` as these don't work in GitHub-flavoured markdown. 