### PR TITLE
Fix COPY command for MATLAB dockerfile.

### DIFF
--- a/docs/platform/tutorials/matlab/matlab-and-simulink.md
+++ b/docs/platform/tutorials/matlab/matlab-and-simulink.md
@@ -490,7 +490,7 @@ Quix supports all versions of MATLAB with support for MATLAB Runtime API. To red
 
 	# MathWorks base dependencies
 	ENV DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC"
-	COPY base-dependencies.txt /tmp/base-dependencies.txt
+	COPY --from=git /project/base-dependencies.txt /tmp/base-dependencies.txt
 	RUN apt-get update && apt-get install --no-install-recommends -y `cat /tmp/base-dependencies.txt` \
 	    && apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/*
 	RUN [ -d /usr/share/X11/xkb ] || mkdir -p /usr/share/X11/xkb
@@ -510,7 +510,7 @@ Quix supports all versions of MATLAB with support for MATLAB Runtime API. To red
 
 	# MathWorks base dependencies
 	ENV DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC"
-	COPY base-dependencies.txt /tmp/base-dependencies.txt
+	COPY --from=git /project/base-dependencies.txt /tmp/base-dependencies.txt
 	RUN apt-get update && apt-get install --no-install-recommends -y `cat /tmp/base-dependencies.txt` \
 	    && apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/*
 	RUN [ -d /usr/share/X11/xkb ] || mkdir -p /usr/share/X11/xkb
@@ -530,7 +530,7 @@ Quix supports all versions of MATLAB with support for MATLAB Runtime API. To red
 
 	# MathWorks base dependencies
 	ENV DEBIAN_FRONTEND="noninteractive" TZ="Etc/UTC"
-	COPY base-dependencies.txt /tmp/base-dependencies.txt
+	COPY --from=git /project/base-dependencies.txt /tmp/base-dependencies.txt
 	RUN apt-get update && apt-get install --no-install-recommends -y `cat /tmp/base-dependencies.txt` \
 	    && apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/*
 	RUN [ -d /usr/share/X11/xkb ] || mkdir -p /usr/share/X11/xkb


### PR DESCRIPTION
## Description
Fix the source path in the `COPY` command.

* [MATLAB tutorial](https://quix.io/docs/platform/tutorials/matlab/matlab-and-simulink.html)
