### PR TITLE
Fix broken image in imported README

### DIFF
--- a/.github/workflows/build-commit-subfolder.yaml
+++ b/.github/workflows/build-commit-subfolder.yaml
@@ -166,7 +166,7 @@ jobs:
     # sed -i 's/old-text/new-text/g' input.txt
     - name: Update intro.md
       shell: bash
-      run: "sed -i 's,https://github.com/quixio/.github/blob/main/profile,./assets,g' docs/quix-streams/quix-streams-intro.md"
+      run: "sed -i 's,https://github.com/quixio/blob/main/images,./assets,g' docs/quix-streams/quix-streams-intro.md"
     
     # Change image paths from ./images to ./assets/client-library
     - name: Update intro.md

--- a/.github/workflows/build-commit-subfolder.yaml
+++ b/.github/workflows/build-commit-subfolder.yaml
@@ -166,7 +166,7 @@ jobs:
     # sed -i 's/old-text/new-text/g' input.txt
     - name: Update intro.md
       shell: bash
-      run: "sed -i 's,https://github.com/quixio/blob/main/images,./assets,g' docs/quix-streams/quix-streams-intro.md"
+      run: "sed -i 's,https://github.com/quixio/quix-streams/blob/main/images,./assets,g' docs/quix-streams/quix-streams-intro.md"
     
     # Change image paths from ./images to ./assets/client-library
     - name: Update intro.md

--- a/.github/workflows/sync-build-deploy.yaml
+++ b/.github/workflows/sync-build-deploy.yaml
@@ -161,7 +161,7 @@ jobs:
       # sed -i 's/old-text/new-text/g' input.txt
       - name: Update intro.md
         shell: bash
-        run: "sed -i 's,https://github.com/quixio/.github/blob/main/profile,./assets,g' docs/quix-streams/quix-streams-intro.md"
+        run: "sed -i 's,https://github.com/quixio/blob/main/images,./assets,g' docs/quix-streams/quix-streams-intro.md"
       
       # Change image paths from ./images to ./assets/client-library
       - name: Update intro.md

--- a/.github/workflows/sync-build-deploy.yaml
+++ b/.github/workflows/sync-build-deploy.yaml
@@ -161,7 +161,7 @@ jobs:
       # sed -i 's/old-text/new-text/g' input.txt
       - name: Update intro.md
         shell: bash
-        run: "sed -i 's,https://github.com/quixio/blob/main/images,./assets,g' docs/quix-streams/quix-streams-intro.md"
+        run: "sed -i 's,https://github.com/quixio/quix-streams/blob/main/images,./assets,g' docs/quix-streams/quix-streams-intro.md"
       
       # Change image paths from ./images to ./assets/client-library
       - name: Update intro.md


### PR DESCRIPTION
## Description

The README on the main branch uses a new URL for the Quix Streams logo, as the logo in .github/profile was never updated. 

The build scripts have therefore been updated to handle this for the README on the main branch ONLY.

## Review

Banner image should be clearly visible on this page:

* [Imported README](https://quixdocsdev.blob.core.windows.net/pr248/quix-streams/quix-streams-intro.html)
