### PR TITLE
Move connectors to top level

### DIFF
--- a/docs/tutorials/influxdb-alerting/summary.md
+++ b/docs/tutorials/influxdb-alerting/summary.md
@@ -6,7 +6,7 @@ You have also seen how to add threshold detection to your pipeline, and built a 
 
 ## Next steps
 
-* Quix Tour demonstrates [building alerting](../../../get-started/quixtour/serve-sms.md) from scratch with the Vonage APIs, which are simple to use.
-* Currency alerting tutorial demonstrates using [Pushover to implement alerting](../../../tutorials/currency-alerting/currency-alerting.md#setting-up-the-pushover-destination).
-* The Predictive maintenance project tutorial uses the Pushover service for [sending alerts](../../../tutorials/predictive-maintenance/phone-alerts.md).
+* Quix Tour demonstrates [building alerting](../../get-started/quixtour/serve-sms.md) from scratch with the Vonage APIs, which are simple to use.
+* Currency alerting tutorial demonstrates using [Pushover to implement alerting](../../tutorials/currency-alerting/currency-alerting.md#setting-up-the-pushover-destination).
+* The Predictive maintenance project tutorial uses the Pushover service for [sending alerts](../../tutorials/predictive-maintenance/phone-alerts.md).
 * [Quix Integrations documentation](../../integrations/overview.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,9 +43,6 @@ nav:
         - 'Personal Access Token (PAT)': 'develop/authentication/personal-access-token.md'
         - 'Streaming Token': 'develop/authentication/streaming-token.md'
       - 'Using Code Samples': 'develop/code-samples.md'
-      - 'Connectors': 
-        - 'connectors/index.md'
-#ConnectorsGetInsertedHere
       - 'Integrate your data':
         - 'Overview': 'develop/integrate-data/overview.md'
         - 'Prebuilt connectors': 'develop/integrate-data/prebuilt-connector.md'
@@ -107,6 +104,9 @@ nav:
         - 'Overview': 'apis/portal-api/overview.md'
         - 'Setup': 'apis/portal-api/setup.md'
         - 'HTTP requests': 'apis/portal-api/http-requests.md'
+  - 'Connectors': 
+    - 'connectors/index.md'
+#ConnectorsGetInsertedHere
   - 'Integrations':
     - 'Overview': 'integrations/overview.md'
     - 'Brokers':

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -243,7 +243,6 @@ plugins:
         'index.md': 'get-started/welcome.md'
         'contribute.md': 'get-started/contribute.md'
         'platform/changes.md': 'get-started/welcome.md'
-        'platform/changes.md#environment': 'create/create-environment.md'
         'platform/ingest-data.md': 'develop/overview.md'
         'platform/quickstart.md': 'get-started/quickstart.md'
         'platform/what-is-quix.md': 'get-started/what-is-quix.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,6 @@ nav:
     - 'Project templates': 'get-started/project-templates.md'
     - 'Quix CLI': 'get-started/cli.md'
     - 'Glossary': 'get-started/glossary.md'
-    #- 'Contribute': 'get-started/contribute.md'
   - 'Using Quix Cloud':
     - '1. Create your project':
       - 'Overview': 'create/overview.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,7 +104,7 @@ nav:
         - 'Setup': 'apis/portal-api/setup.md'
         - 'HTTP requests': 'apis/portal-api/http-requests.md'
   - 'Connectors': 
-    - 'connectors/index.md'
+    - 'connectors/index.md':
 #ConnectorsGetInsertedHere
   - 'Integrations':
     - 'Overview': 'integrations/overview.md'


### PR DESCRIPTION
## Description

Moves Connectors documentation to top level for greater discoverability / visibility.

Note: links don't need changing as the docs files themselves have not been moved - only the location in the TOC has changed.

## Review

* Check top level, connectors should be in the TOC.
* Check some links to connectors - they should still work.