### PR TITLE
Update InfluxDB Quickstart

### DIFF
--- a/docs/integrations/databases/influxdb/quickstart.md
+++ b/docs/integrations/databases/influxdb/quickstart.md
@@ -9,7 +9,7 @@ search:
 
 This quickstart shows you how to integrate Quix with InfluxDB using our standard [connectors](../../../connectors/index.md).
 
-In the first part of this quickstart, you'll read time series data, transform it, and then publish it to InfluxDB.
+In the first part of this quickstart, you'll read F1 car telemetry data, transform it, and then publish it to InfluxDB.
 
 In the second part you'll get data from InfluxDB and publish it into a Quix topic, explore that data in real time.
 
@@ -159,7 +159,7 @@ You will now check that your InfluxDB database is receiving data.
 
 2. Under `Measurement` select `f1-data` and click `Run`. You see the data stored in InfluxDB.
 
-You have successfully processed time series data and published it from Quix to InfluxDB.
+You have successfully processed F1 car telemetry data and published it from Quix to InfluxDB.
 
 !!! note
 

--- a/docs/integrations/databases/influxdb/quickstart.md
+++ b/docs/integrations/databases/influxdb/quickstart.md
@@ -222,7 +222,7 @@ You'll now add a transform service to your Influx query to calculate the average
     sdf = app.dataframe(input_topic)
 
     # Filter in messages containing speed values
-    sdf = sdf[sdf["Speed"]]
+    sdf = sdf[["Speed"]]
     # Calculate average speed over 10 second window
     sdf = sdf.tumbling_window(timedelta(seconds=10)).mean().final()
 

--- a/docs/integrations/databases/influxdb/quickstart.md
+++ b/docs/integrations/databases/influxdb/quickstart.md
@@ -141,7 +141,7 @@ You can now add an InfluxDB **destination** to enable you to publish data from a
         | `INFLUXDB_TAG_COLUMNS` | Leave as default, `['tag1', 'tag2']`. |
         | `INFLUXDB_MEASUREMENT_NAME` | The "table" name, in this case `f1-data`. |
         | `CONSUMER_GROUP_NAME` | Consumer group name, for example `influxdb-sink`. |
-        | `TIMESTAMP_COLUMN` | Leave blank. |
+        | `TIMESTAMP_COLUMN` | A timestamp field with the time in nanoseconds. |
 
 5. Click the `Run` button to test connection with the database. If no errors occur, proceed to the next step, or otherwise check you have configured your environment variables correctly.
 

--- a/docs/integrations/databases/influxdb/replacing-flux.md
+++ b/docs/integrations/databases/influxdb/replacing-flux.md
@@ -38,7 +38,7 @@ output_topic = app.topic(os.environ["output"])
 sdf = app.dataframe(input_topic)
 
 # Filter in Speed
-sdf = sdf[sdf["Speed"]]
+sdf = sdf[["Speed"]]
 
 # Calculate mean of speed over 10 second tumbling window
 sdf = sdf.tumbling_window(timedelta(seconds=10)).mean().final()

--- a/docs/integrations/databases/influxdb/replacing-flux.md
+++ b/docs/integrations/databases/influxdb/replacing-flux.md
@@ -138,10 +138,7 @@ sdf = sdf.update(lambda row: print(row))
 sdf = sdf.to_topic(output_topic)
 
 if __name__ == "__main__":
-    try:
-        app.run(sdf)
-    except Exception as e:
-        logger.exception("An error occurred while running the application. {e}")
+    app.run(sdf)
 ```
 
 Data is consumed in MessagePack format, and produced in JSON format, for onward processing by the pipeline. This example demonstrates the very flexible approach to data conversion that a fully featured programming language such as Python provides.

--- a/docs/integrations/databases/influxdb/replacing-flux.md
+++ b/docs/integrations/databases/influxdb/replacing-flux.md
@@ -141,7 +141,7 @@ if __name__ == "__main__":
     try:
         app.run(sdf)
     except Exception as e:
-        logger.exception("An error occurred while running the application.", e)
+        logger.exception("An error occurred while running the application. {e}")
 ```
 
 Data is consumed in MessagePack format, and produced in JSON format, for onward processing by the pipeline. This example demonstrates the very flexible approach to data conversion that a fully featured programming language such as Python provides.

--- a/docs/integrations/databases/influxdb/replacing-flux.md
+++ b/docs/integrations/databases/influxdb/replacing-flux.md
@@ -22,28 +22,25 @@ Downsampling data involves performing some type of aggregation. Quix Streams has
 * `count()` - to count the number of values within a window
 * `reduce()` - to perform custom aggregations using "reducer" and "initializer" functions
 
-For example, you can easily calculate average over tumbling or hopping windows. The following example shows filtering and calculating an average of vehicle speed using a tumbling window:
+For example, you can easily calculate average over tumbling or hopping windows. The following example shows **filtering** and **calculating an average** of vehicle speed using a tumbling window:
 
 ``` python
 import os
 from quixstreams import Application, State
-from quixstreams.models.serializers.quix import QuixDeserializer, JSONSerializer
 from datetime import timedelta
 
-def my_func(row):
-    return row['Speed']
-
 app = Application.Quix("transformation-v1", auto_offset_reset="latest")
-input_topic = app.topic(os.environ["input"], value_deserializer=QuixDeserializer())
-output_topic = app.topic(os.environ["output"], value_serializer=JSONSerializer())
+
+input_topic = app.topic(os.environ["input"])
+output_topic = app.topic(os.environ["output"])
 
 # Read from input topic
 sdf = app.dataframe(input_topic)
 
-# Put transformation logic here.
-sdf = sdf.filter(lambda row: 'Speed' in row)
-sdf = sdf.filter(lambda row: row['Speed'] != None)
-sdf = sdf.apply(my_func)
+# Filter in Speed
+sdf = sdf[sdf["Speed"]]
+
+# Calculate mean of speed over 10 second tumbling window
 sdf = sdf.tumbling_window(timedelta(seconds=10)).mean().final()
 
 # Print every row
@@ -55,8 +52,6 @@ sdf = sdf.to_topic(output_topic)
 if __name__ == "__main__":
     app.run(sdf)
 ```
-
-The `filter` function is used to filter any rows where `Speed` is not present, or where `Speed` has a value of `None`. This prevents errors when calculating aggregations.
 
 This would publish average speed to the output topic, and that could then be used as the basis of further processing, or simply stored in InfluxDB.
 
@@ -74,101 +69,82 @@ sdf = sdf.tumbling_window(timedelta(weeks=1)).mean().final()
 
 See the [Quix Streams documentation](https://quix.io/docs/quix-streams/introduction.html) for more information.
 
-## Filtering messages using Quix Streams
+## Converting data
 
-You have seen an example of filtering data from the stream of messages using the `filter` function. You can also do this by modifying the `StreamingDataFrame` data structure, rather than using the `filter` function, as shown in the following example:
+Sometimes you need to convert data from one format to another. This can be done with great flexibility in Python. For example, in IoT applications, some smart devices send data in [MessagePack](https://msgpack.org/){target=_blank} format. For example, here's the CPU example from the [Quix Quickstart](../../../get-started/quickstart.md) converted to pack data in MessagePack format:
+
+``` python
+import psutil, time, os, msgpack
+from quixstreams import Application
+
+from dotenv import load_dotenv
+load_dotenv()
+
+app = Application.Quix()
+
+output_topic = app.topic("cpu-load", value_serializer="bytes")
+    
+def get_cpu_load():
+    cpu_load = psutil.cpu_percent(interval=1)
+    memory = psutil.swap_memory()
+    return {
+        "cpu_load": cpu_load,
+        "memory": memory._asdict(),
+        "timestamp": int(time.time_ns()),
+    }
+
+def main():
+    with app.get_producer() as producer:
+        while True:                
+            message = get_cpu_load()
+            packed_message = msgpack.packb(message) # pack data in MessagePack format
+            
+            producer.produce(
+            topic=output_topic.name,
+                key="server-1-cpu",
+                value=packed_message
+            )
+
+if __name__ == '__main__':
+    try:
+        main()
+    except KeyboardInterrupt:
+        print('Exiting due to keyboard interrupt')    
+```
+
+Quix Streams is able to handle binary data as bytes. It publishes packed data to the output topic in binary MessagePack format.
+
+In Quix, a transform to convert this data to JSON would be:
 
 ``` python
 import os
-from quixstreams import Application, State
-from quixstreams.models.serializers.quix import QuixDeserializer, JSONSerializer
+from quixstreams import Application
+import msgpack
+
+from dotenv import load_dotenv
+load_dotenv()
+
+def unpack(row):
+    return msgpack.unpackb(row)
 
 app = Application.Quix("transformation-v1", auto_offset_reset="latest")
 
-input_topic = app.topic(os.environ["input"], value_deserializer=QuixDeserializer())
-output_topic = app.topic(os.environ["output"], value_serializer=JSONSerializer())
+input_topic = app.topic(os.environ["input"], value_deserializer="bytes")
+output_topic = app.topic(os.environ["output"], value_serializer="json")
 
-# Read from input topic
 sdf = app.dataframe(input_topic)
-
-# Put transformation logic.
-sdf = sdf.filter(lambda row: 'Speed' in row)
-sdf = sdf.filter(lambda row: row['Speed'] != None)
-sdf = sdf[["Timestamp", "Speed", "EngineRPM"]]
+sdf = sdf.apply(unpack)
 sdf = sdf.update(lambda row: print(row))
-
-# Publish to output topic
 sdf = sdf.to_topic(output_topic)
 
 if __name__ == "__main__":
-    app.run(sdf)
+    try:
+        app.run(sdf)
+    except Exception as e:
+        logger.exception("An error occurred while running the application.", e)
 ```
 
-The following code drops all columns in the row, other than those specified:
-
-```python
-sdf = sdf[["Timestamp", "Speed", "EngineRPM"]]
-```
-
-Only certain data needs to be published to the output topic - just `Timestamp`, `Speed`, and `EngineRPM` are required in this use case. 
-
-## Converting time series data to simple JSON format
-
-In a simple Quix transform you might subscribe to, and publish, data in Quix format, for example:
-
-``` python
-import os
-from quixstreams import Application, State
-from quixstreams.models.serializers.quix import QuixDeserializer, QuixTimeseriesSerializer
-
-app = Application.Quix("transformation-v1", auto_offset_reset="latest")
-
-input_topic = app.topic(os.environ["input"], value_deserializer=QuixDeserializer())
-output_topic = app.topic(os.environ["output"], value_serializer=QuixTimeseriesSerializer())
-
-sdf = app.dataframe(input_topic)
-
-# Put transformation logic here. 
-
-# Print every row
-sdf = sdf.update(lambda row: print(row))
-
-sdf = sdf.to_topic(output_topic)
-
-if __name__ == "__main__":
-    app.run(sdf)
-```
-
-In this example, data is subscribed to and published using Quix format. 
-
-You can easily convert from the Quix format to a simple JSON format (or the other way around) using serializers and deserializers built into Quix Streams, for example, to convert from Quix format to a simple JSON format, you could modify the above code to the following:
-
-``` python
-import os
-from quixstreams import Application, State
-from quixstreams.models.serializers.quix import QuixDeserializer, JSONSerializer
-
-app = Application.Quix("transformation-v1", auto_offset_reset="latest")
-
-input_topic = app.topic(os.environ["input"], value_deserializer=QuixDeserializer())
-output_topic = app.topic(os.environ["output"], value_serializer=JSONSerializer())
-
-sdf = app.dataframe(input_topic)
-
-# Put transformation logic here.    
-
-# Print every row
-sdf = sdf.update(lambda row: print(row))
-
-sdf = sdf.to_topic(output_topic)
-
-if __name__ == "__main__":
-    app.run(sdf)
-```
-
-Notice that the Quix deserializer has been replaced by the JSON deserializer.
-
-This would read data on the topic in Quix time series format, and publish the data converted to JSON format.
+Data is consumed in MessagePack format, and produced in JSON format, for onward processing by the pipeline. This example demonstrates the very flexible approach to data conversion that a fully featured programming language such as Python provides.
 
 ## Next steps
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -299,6 +299,7 @@ plugins:
         'integrations/influxdb/telegraf.md': 'integrations/databases/influxdb/telegraf.md'
         'integrations/influxdb/replacing-flux.md': 'integrations/databases/influxdb/replacing-flux.md'
         'platform/how-to/use-sdk-token.md': 'develop/authentication/streaming-token.md'
+        'platform/get-started/quixtour/ingest-push.md': 'platform/get-started/quixtour/external-source.md'
 
 theme:
   name: 'material'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -293,13 +293,15 @@ plugins:
         'platform/how-to/replay.md': 'manage/replay.md'
         'platform/how-to/create-project.md': 'create/create-project.md'
         'client-library-intro.md': 'quix-streams/introduction.md'
+        'quix-streams/client-library-intro.md': 'quix-streams/introduction.md'
         'quix-streams-intro.md': 'quix-streams/introduction.md'
+        'quix-streams/quix-streams-intro.md': 'quix-streams/introduction.md'
         'integrations/influxdb/overview.md': 'integrations/databases/influxdb/overview.md'
         'integrations/influxdb/quickstart.md': 'integrations/databases/influxdb/quickstart.md'
         'integrations/influxdb/telegraf.md': 'integrations/databases/influxdb/telegraf.md'
         'integrations/influxdb/replacing-flux.md': 'integrations/databases/influxdb/replacing-flux.md'
         'platform/how-to/use-sdk-token.md': 'develop/authentication/streaming-token.md'
-        'platform/get-started/quixtour/ingest-push.md': 'platform/get-started/quixtour/external-source.md'
+        'platform/get-started/quixtour/ingest-push.md': 'get-started/quixtour/external-source.md'
 
 theme:
   name: 'material'


### PR DESCRIPTION
## Description

- [x] Update the InfluxDB Quickstart. We've made some improvements to the connectors, and they no longer use Quix data format, which changes things as we now use JSON.
- [x] Code tweaks too, as JSON is default format, serializers/deserializers do not need to be specified.
- [x] The "Replacing Flux" topic also needs to be updated, and that is to be done on this PR too.
