### PR TITLE
Add warnings for legacy features

### DIFF
--- a/docs/apis/query-api/overview.md
+++ b/docs/apis/query-api/overview.md
@@ -7,6 +7,10 @@ description: The Query API enables you to fetch persisted data stored in the Qui
 
 The Query API enables you to fetch persisted data stored in the Quix platform. You can use it for exploring the platform, prototyping applications, or working with stored data in any language with HTTP capabilities.
 
+!!! danger "Legacy feature"
+
+	This feature is not available to new users. However, legacy users may still have access to this functionality.
+
 !!! note
 
     The Query API is primarily designed for **testing purposes only**. For production storage of data, Quix recommends using one of the numerous [connectors](../../connectors/index.md) to persist data in the database technology of your choice.

--- a/docs/create/create-environment.md
+++ b/docs/create/create-environment.md
@@ -135,10 +135,10 @@ When this option is selected, data in the topic is persisted to a Quix database 
 Services that experience improved performance when selecting the "High performance" option include the following:
 
 * GitService - this is the service that synchronizes your Quix environment with the project's Git repository.
-* [Replay Service](../manage/replay.md) - enables replay of persisted data into a topic.
+* [Replay Service](../manage/replay.md) - enables replay of persisted data into a topic. **Note:** feature is only available to legacy customers.
 * [Streaming Reader](../apis/streaming-reader-api/overview.md) - service that enables a client to subscribe to a Quix topic.
 * [Streaming Writer](../apis/streaming-writer-api/overview.md) - service that enables a client to publish to a Quix topic.
-* [Query API](../apis/query-api/overview.md) - query data persisted in the Quix database.
+* [Query API](../apis/query-api/overview.md) - query data persisted in the Quix database. **Note:** feature is only available to legacy customers.
 
 Generally, if you notice sluggish performance in one of these services, it may mean for the volumes and frequency of data you are processing, you might need the High performance option.
 

--- a/docs/create/create-environment.md
+++ b/docs/create/create-environment.md
@@ -116,6 +116,10 @@ These options determine the following:
 
 ### Persisted storage
 
+!!! danger "Legacy feature"
+
+	This feature is not available to new users. However, legacy users may still have access to this functionality.
+
 Persisted storage is when you enable persistence on a topic: 
 
 ![Topic persistence](../images/create-environment/topic-persistence.png){width=80%}

--- a/docs/develop/integrate-data/jupyter-nb.md
+++ b/docs/develop/integrate-data/jupyter-nb.md
@@ -2,6 +2,10 @@
 
 In this documentation, you learn how to use Jupyter Notebook to analyze data persisted in Quix.
 
+!!! danger "Legacy features"
+
+	Some of the features on this page are not available to new users, including those related to the Quix Data Explorer and the topic Persistence feature. However, legacy users may still have access to these facilities. 
+
 ## Why this is important
 
 Although Quix is a real-time platform, to build real-time in-memory models and data processing pipelines, you need to understand data first. To help with that, Quix offers the option to persist data in topics. This data can be accessed using the [Query API](../../apis/query-api/overview.md). This helps make data discovery and analysis easier.

--- a/docs/kb/glossary.md
+++ b/docs/kb/glossary.md
@@ -168,6 +168,10 @@ A project contains one or more [environments](#environment), so typically you cr
 
 ## Query API
 
+!!! danger "Legacy feature"
+
+	This feature is not available to new users. However, legacy users may still have access to this functionality.
+
 The [Query API](../apis/query-api/overview.md) is used to query persisted data. Most commonly used for dashboards, analytics and training ML models. Also useful to call historical data when running an ML model, or to call historical data from an external application. This API is primarily iused for testing and debugging purposes.
 
 ## Quix UI

--- a/docs/kb/what-is-quix.md
+++ b/docs/kb/what-is-quix.md
@@ -32,7 +32,7 @@ Briefly, here's how you would build a Python stream processing pipeline with Qui
 
 Quix is designed to remove as much complexity as possible from the process of creating, deploying, and monitoring your streaming data pipelines.
 
-Quix leverages industry-standard technologies, such as Kafka to provide the core functionality for data streaming, Kubernetes for scaling your deployments, InfluxDB and MongoDB for data persistence, Git for revision control, and Python as the main language for programming your solutions.
+Quix leverages industry-standard technologies, such as Kafka to provide the core functionality for data streaming, Kubernetes for scaling your deployments, Git for revision control, and Python as the main language for programming your solutions.
 
 The following sections take a look at the key components of creating your streaming data solutions:
 

--- a/docs/kb/what-is-quix.md
+++ b/docs/kb/what-is-quix.md
@@ -144,9 +144,9 @@ Quix provides numerous standard [connectors](../connectors/index.md) for both so
 
 Quix provides several APIs to help you work with streaming data. These include:
 
-* [**Stream Writer API**](../apis/streaming-writer-api/overview.md): enables you to send any data to a Kafka topic in Quix using HTTP. This API handles encryption, serialization, and conversion to the Quix Streams format, ensuring efficiency and performance of down-stream processing regardless of the data source.
-* [**Stream Reader API**](../apis/streaming-reader-api/overview.md): enables you to push live data from a Quix topic to your application, ensuring low latency by avoiding any disk operations.
-* [**Query API**](../apis/query-api/overview.md): enables you to query persisted data streams. This is provided primarily for testing purposes. 
+* [**Streaming Writer API**](../apis/streaming-writer-api/overview.md): enables you to send any data to a Kafka topic in Quix using HTTP. This API handles encryption, serialization, and conversion to the Quix Streams format, ensuring efficiency and performance of down-stream processing regardless of the data source.
+* [**Streaming Reader API**](../apis/streaming-reader-api/overview.md): enables you to push live data from a Quix topic to your application, ensuring low latency by avoiding any disk operations.
+* [**Query API**](../apis/query-api/overview.md): enables you to query persisted data streams. This is provided primarily for testing purposes. **Note:** available to legacy customers only.
 * [**Portal API**](../apis/portal-api/overview.md): enables you to automate Quix tasks such as creating environments, topics, and deployments.
 
 ### Quix Streams

--- a/docs/manage/overview.md
+++ b/docs/manage/overview.md
@@ -71,11 +71,19 @@ The replay service is used to play back persisted data into a topic.
 
 ## Replay service
 
+!!! danger "Legacy feature"
+
+	This feature is not available to new users. However, legacy users may still have access to this functionality.
+
 The replay service enables you to play persisted data back into a topic.
 
 You can read more about the [replay service](./replay.md) in the docs.
 
 ## Query API
+
+!!! danger "Legacy feature"
+
+	This feature is not available to new users. However, legacy users may still have access to this functionality.
 
 The Query API enables you to programmatically retrieve persisted data from the database.
 

--- a/docs/manage/overview.md
+++ b/docs/manage/overview.md
@@ -25,13 +25,21 @@ There is also a tab with messages view. This is described in a later section.
 
 ## Data explorer
 
+!!! danger "Legacy feature"
+
+	This feature is not available to new users. However, legacy users may still have access to this functionality.
+
 When your pipeline is running, and the applications are generating data on topics, you can use the Data Explorer to view data in real time.
 
 You can select the topic you want to view data on, and then the stream within that topic, as well as the specific parameters and events you are interested in. These can be displayed in waveform, table, or message view. The following screenshot illustrates the waveform view:
 
 ![Data explorer](../images/manage/data-explorer.png)
 
-Table view enables you to view the parameter data in a tabular format, and messages view enables you to view the raw message data. 
+Table view enables you to view the parameter data in a tabular format, and messages view enables you to view the raw message data.
+
+!!! tip
+
+    You can access similar functionality by clicking `Topics` in the left-hand sidebar, and then clicking on the topic whose messages you want to view. 
 
 ## Message viewer
 
@@ -42,6 +50,10 @@ The message view shows the raw message format. The message viewer is available n
 The data explorer also has a message viewer tab, as can be seen in the [data explorer section](#data-explorer).
 
 ## Persistence
+
+!!! danger "Legacy feature"
+
+	This feature is not available to new users. However, legacy users may still have access to this functionality.
 
 While data in a Kafka topic is retained according to the topic retention time configured when you create a new topic:
 

--- a/docs/manage/replay.md
+++ b/docs/manage/replay.md
@@ -1,5 +1,9 @@
 # How to replay data
 
+!!! danger "Legacy feature"
+
+	This feature is not available to new users. However, legacy users may still have access to this functionality.
+
 Quix features a **replay service**. This service enables you to replay persisted data into a topic, as if it were live data. This is very useful for the following use cases:
 
 * Testing and debugging connectors and transforms

--- a/docs/manage/testing-data-store.md
+++ b/docs/manage/testing-data-store.md
@@ -16,6 +16,10 @@ Quix provides a very simple way to persist data in a topic. Simply locate the to
 
 ## Replay service
 
+!!! danger "Legacy feature"
+
+	This feature is not available to new users. However, legacy users may still have access to this functionality.
+
 When data has been persisted, you have the option to not only query and display it, but replay it into your pipeline. This can be very useful for testing and debugging pipelines using historical data.
 
 See how to [use the Quix replay service](../manage/replay.md).

--- a/docs/manage/testing-data-store.md
+++ b/docs/manage/testing-data-store.md
@@ -1,5 +1,9 @@
 # Data store for testing 
 
+!!! danger "Legacy feature"
+
+	This feature is not available to new users. However, legacy users may still have access to this functionality.
+
 Quix provides a data store for testing and debugging purposes.
 
 While [topics](../kb/glossary.md#topic) do provide a configurable retention time, persisting data into a database provides advantages - for example, you can perform powerful queries to retrieve historical data. This data can be retrieved and displayed using the Data Explorer, or retrieved using the [Query API](../apis/query-api/overview.md).

--- a/docs/tutorials/data-science/3-data.md
+++ b/docs/tutorials/data-science/3-data.md
@@ -4,6 +4,10 @@
 
     This tutorial is out of date. Please check the [tutorials overview](../overview.md) for our latest tutorials.
 
+!!! danger "Legacy feature"
+
+	This feature is not available to new users. However, legacy users may still have access to this functionality.
+
 With Quix it's easy to visualize your data in a powerful and flexible way, you can see the data in real time, as well as viewing historical data.
 
 Quix was designed for real-time data, so if you want to see data-at-rest for any topic you must turn on data persistence for that specific topic. You'll do this in the [historical data](#historical-data) section.

--- a/docs/tutorials/predictive-maintenance/data-generator.md
+++ b/docs/tutorials/predictive-maintenance/data-generator.md
@@ -27,7 +27,7 @@ This service runs continually.
 
 ## Exploring the message format
 
-If you click `Topics` in the main left-hand navigation you see the topics in the environment. Click in the `Data` area to view live data. This takes you into the Quix data explorer. You can then select the stream and parameter data you'd like to explore. You can then view this data in either the `Table` or `Messages` view.
+If you click `Topics` in the main left-hand navigation you see the topics in the environment. Click the topic to view live data. You can then view this data in either the `Table` or `Messages` view.
 
 If you look at the messages in the `Messages` view, you'll see data has the following format:
 
@@ -43,7 +43,7 @@ If you look at the messages in the `Messages` view, you'll see data has the foll
 }
 ```
 
-The Quix data explorer is a very useful tool for debugging and monitoring your pipeline.
+The Quix topic explorer's message view is a very useful tool for debugging and monitoring your pipeline.
 
 ## Viewing the deployed application
 

--- a/docs/tutorials/predictive-maintenance/summary.md
+++ b/docs/tutorials/predictive-maintenance/summary.md
@@ -6,7 +6,7 @@ In addition, you have seen how in Quix you can:
 
 * See the power of navigating your pipeline visually
 * View the logs of a service as an aid to debugging
-* View live data in the application view, or using the Quix Data Explorer
+* View live data in the application view, or using the Quix topic explorer
 * Learned how you can host your project in a Git repository
 * Learn how to examine the raw message data in the messages view
 * Examine and edit the code of a service

--- a/docs/tutorials/train-and-deploy-ml/create-data.md
+++ b/docs/tutorials/train-and-deploy-ml/create-data.md
@@ -4,6 +4,10 @@
 
     This tutorial is out of date. Please check the [tutorials overview](../overview.md) for our latest tutorials.
 
+!!! danger "Legacy feature"
+
+	This feature is not available to new users. However, legacy users may still have access to this functionality.
+
 In this part of the tutorial you learn how to obtain some real-time data to work with in the rest of the tutorial. You use a demo data source that generates Formula 1 race car data from a computer game. You use this data as the basis to build a ML model to predict braking patterns.
 
 ## Create a persisted topic

--- a/docs/tutorials/train-and-deploy-ml/overview.md
+++ b/docs/tutorials/train-and-deploy-ml/overview.md
@@ -1,6 +1,6 @@
 # Real-time Machine Learning (ML) pipelines
 
-!!! warning
+!!! danger
 
     This tutorial is out of date. Please check the [tutorials overview](../overview.md) for our latest tutorials.
 


### PR DESCRIPTION
## Description

New users no longer have access to Data Explorer and Data Persistence. This means related features are also not available, for example the Replay Service and Query API are not usable without persistence. 

## Review

Check the diff.