### PR TITLE
Remove references to binary data in APIs and SDK

### DIFF
--- a/docs/apis/query-api/aggregate-tags.md
+++ b/docs/apis/query-api/aggregate-tags.md
@@ -69,7 +69,6 @@ Standard aggregation functions are provided including `max`, `count`, and `sprea
     ]
   },
   "stringValues": {},
-  "binaryValues": {},
   "tagValues": {
     "LapNumber": [
       "3.0",

--- a/docs/apis/query-api/raw-data.md
+++ b/docs/apis/query-api/raw-data.md
@@ -20,7 +20,7 @@ You can filter by a number of different factors but, at minimum, you’ll need t
 }
 ```
 
-In this example, we’re requesting a single numeric parameter, `Speed`. Each array of parameters is indexed based on parameter type, which can be `numericParameters`, `stringParameters` or `binaryParameters`. Parameters are returned in a union, so if you request several, you’ll get back all parameters that match.
+In this example, we’re requesting a single numeric parameter, `Speed`. Each array of parameters is indexed based on parameter type, which can be `numericParameters` or `stringParameters`. Parameters are returned in a union, so if you request several, you’ll get back all parameters that match.
 
 ### Example
 
@@ -45,7 +45,6 @@ If you just had a single parameter value in the stored data, the response from t
         ]
     },
     "stringValues": {},
-    "binaryValues": {},
     "tagValues": {},
 }
 ```

--- a/docs/apis/streaming-writer-api/send-data.md
+++ b/docs/apis/streaming-writer-api/send-data.md
@@ -22,14 +22,13 @@ You should replace `${topicName}` with the name of the topic your stream belongs
 
 ### Example request
 
-Your payload should include an array of `timestamps` with one timestamp for each item of data you’re sending. Actual data values should be keyed on their name, in the object that corresponds to their type, one of `numericValues`, `stringValues`, or `binaryValues`. The payload is in this structure:
+Your payload should include an array of `timestamps` with one timestamp for each item of data you’re sending. Actual data values should be keyed on their name, in the object that corresponds to their type, one of `numericValues` or `stringValues`. The payload is in this structure:
 
 ```json
 {
     "timestamps": [...],
     "numericValues": {...},
     "stringValues": {...},
-    "binaryValues": {...},
     "tagValues": {...}
 }
 ```
@@ -128,13 +127,6 @@ connection.start().then(async () => {
           "Hello",
           "World",
           "!"
-        ]
-      },
-      "binaryValues": {
-        "BinaryParameter1": [
-          btoa("Hello"), // send binary array as base64
-          btoa("World"),
-          btoa("!")
         ]
       },
       "tagValues": {

--- a/docs/kb/glossary.md
+++ b/docs/kb/glossary.md
@@ -14,12 +14,6 @@ Applications in Quix exist inside the Git branch associated with an [environment
 
 Read more about [applications](../create/overview.md).
 
-## Binary data
-
-Quix also supports any binary blob data.
-
-With this data you can stream, process and store any type of audio, image, video or lidar data, or anything that isn’t supported with time series, event, or metadata types.
-
 ## Code Samples
 
 Quix contains a large number of [open source](https://github.com/quixio/quix-samples){target=_blank} Code Samples. You can use these to quickly build out your stream processing pipeline. Generally the code samples are divided into three main categories: source, transform, destination. You can access the Code Samples from within the UI by using the navigation menu as show here:
@@ -48,11 +42,10 @@ Read more about [data ingestion](../develop/integrate-data/overview.md).
 
 ## Data types
 
-Quix supports time series data, events, metadata, and blobs with the following data types: 
+Quix supports time series data, events and metadata with the following data types: 
 
 * Numeric (double precision)
 * String (UTF-8)
-* Binary data (blobs)
 
 ## Deployment
 
@@ -194,7 +187,7 @@ A type of [connector](../connectors/index.md) where data is published to a Quix 
 
 ## Stream
 
-A stream is a collection of data (time series data, events, binary blobs and metadata) that belong to a single session of a single source. For example:
+A stream is a collection of data (time series data, events and metadata) that belong to a single session of a single source. For example:
 
 * One journey for one car
 * One game session for one player

--- a/docs/tutorials/clickstream/clickstream-producer.md
+++ b/docs/tutorials/clickstream/clickstream-producer.md
@@ -55,7 +55,6 @@ If you look at the messages in the `Messages` view, you'll see data has the foll
       "VD55179433"
     ]
   },
-  "BinaryValues": {},
   "TagValues": {}
 }
 ```

--- a/docs/tutorials/clickstream/data-enrichment.md
+++ b/docs/tutorials/clickstream/data-enrichment.md
@@ -58,7 +58,6 @@ The enriched data format:
       "F"
     ]
   },
-  "BinaryValues": {},
   "TagValues": {}
 }
 ```

--- a/docs/tutorials/computer-vision/add-service.md
+++ b/docs/tutorials/computer-vision/add-service.md
@@ -126,7 +126,6 @@ To create the transform:
                 "iVBOR/snip/QmCC"
                 ]
             },
-            "BinaryValues": {},
             "TagValues": {
                 "parent_streamId": [
                 "JamCams_00002.00820"

--- a/docs/tutorials/computer-vision/object-detection.md
+++ b/docs/tutorials/computer-vision/object-detection.md
@@ -60,11 +60,6 @@ Objects are detected in the frame by the YOLOv8 code. Data is published to the o
     ]
   },
   "StringValues": {},
-  "BinaryValues": {
-    "image": [
-      "(Binary of 152.47 KB)"
-    ]
-  },
   "TagValues": {}
 }
 ```

--- a/docs/tutorials/computer-vision/other-services.md
+++ b/docs/tutorials/computer-vision/other-services.md
@@ -125,7 +125,6 @@ The max vehicles service takes the total vehicle count and finds the maximum val
     ]
   },
   "StringValues": {},
-  "BinaryValues": {},
   "TagValues": {
     "window_start": [
       "2023-09-06 12:08:12.394372"

--- a/docs/tutorials/computer-vision/web-ui.md
+++ b/docs/tutorials/computer-vision/web-ui.md
@@ -101,7 +101,6 @@ The data read from the topic is as follows:
         "iVBO…to/v37HG18UyZ1Qz/fby/<snipped>+yXUGc5UVWZfIHnX0iqM6aEAAAAASUVORK5CYII="
     ]
   },
-  "BinaryValues": {},
   "TagValues": {
     "parent_streamId": [
       "JamCams_00001.02500"

--- a/docs/tutorials/event-detection/data-acquisition.md
+++ b/docs/tutorials/event-detection/data-acquisition.md
@@ -259,7 +259,6 @@ Follow these instructions to deploy the data source:
 			"Battery"
 			]
 		},
-		"BinaryValues": {},
 		"TagValues": {}
 		}
 

--- a/docs/tutorials/sentiment-analysis/sentiment-analysis-service.md
+++ b/docs/tutorials/sentiment-analysis/sentiment-analysis-service.md
@@ -63,7 +63,6 @@ There are several ways to view live data. This lab shows one way to do it.
         "Can you check on my order please?"
         ]
     },
-    "BinaryValues": {},
     "TagValues": {
         "room": [
         "channel"

--- a/docs/tutorials/sentiment-analysis/twitch-service.md
+++ b/docs/tutorials/sentiment-analysis/twitch-service.md
@@ -53,7 +53,6 @@ The message format on the output `messages` topic:
       "@CaalvaVoladora Boomerdemons is also up"
     ]
   },
-  "BinaryValues": {},
   "TagValues": {
     "room": [
       "channel"


### PR DESCRIPTION
## Description

Quixstreams <1 had support specific binary parameters, however in quixstreams 2.x messages were designed to be less strict in schema. With that, Binary messages are possible if serialization is provided and don't need special handling. In some deprecated Quix APIs there was support for these parameters but that support is now removed.

## Review

It is only deletion and mostly on pages with warning of it being outdated anyway. I left the property in for samples that specifically worked with it but all are outdated anyway.