### PR TITLE
Remove cloud first option

### DIFF
--- a/RUNNING-DOCS-LOCALLY.md
+++ b/RUNNING-DOCS-LOCALLY.md
@@ -39,5 +39,5 @@ To view the docs locally:
    git clone https://github.com/quixio/quix-docs.git
    ```
 3. Change into the docs directory you cloned (there will be a `mkdocs.yml` file there). 
-4. Run `mkdocs serve`.
+4. Run `mkdocs serve --no-directory-urls`.
 5. Navigate your browser to `localhost:8000` to view the docs.

--- a/docs/get-started/welcome.md
+++ b/docs/get-started/welcome.md
@@ -9,20 +9,12 @@ description: Welcome to the Quix Developer documentation. This documentation inc
 
 <div class="grid cards" markdown>
 
-- __I'm comfortable on the command line__
+- __Build a pipeline__
 
     ---
 
-    Start building your stream processing pipeline on the command line with Quix Streams and the Quix CLI.
+    Start building your stream processing pipeline on the command line with Quix Streams.
 
     [Install Quix Streams :octicons-arrow-right-24:](./install.md)
-
-- __I'd rather use the Cloud__
-
-    ---
-
-    You can sign up to [Quix Cloud for free](https://portal.platform.quix.io/self-sign-up){target=_blank}, and then build a stream processing pipeline with Quix Streams and Quix Cloud in under ten minutes.
-
-    [Quix Cloud Quickstart :octicons-arrow-right-24:](../quix-cloud/quickstart.md)
 
 </div>

--- a/docs/get-started/welcome.md
+++ b/docs/get-started/welcome.md
@@ -7,13 +7,19 @@ description: Welcome to the Quix Developer documentation. This documentation inc
 
 <p style="font-size: 1rem;">Quix is a complete platform for developing, deploying, and monitoring stream processing pipelines. You develop your <b>pipeline services in Python</b> using Quix Streams, and deploy them to containers managed in Kubernetes with a single click. You can develop and manage services on the command line, and also manage and visualize your pipelines in Quix Cloud.</p>
 
+Your Quix workflow:
+
+1. Develop your applications locally in Python with Quix Streams and the Quix CLI
+2. Test your pipeline locally with Quix CLI
+3. Deploy to Quix Cloud for scalability and observability
+
 <div class="grid cards" markdown>
 
-- __Build a pipeline__
+- __Get started!__
 
     ---
 
-    Start building your stream processing pipeline on the command line with Quix Streams.
+    Start building your stream processing pipeline locally on the command line with Quix Streams.
 
     [Install Quix Streams :octicons-arrow-right-24:](./install.md)
 

--- a/docs/get-started/welcome.md
+++ b/docs/get-started/welcome.md
@@ -5,13 +5,15 @@ description: Welcome to the Quix Developer documentation. This documentation inc
 
 # Welcome
 
-<p style="font-size: 1rem;">Quix is a complete platform for developing, deploying, and monitoring stream processing pipelines. You develop your <b>pipeline services in Python</b> using Quix Streams, and deploy them to containers managed in Kubernetes with a single click. You can develop and manage services on the command line, and also manage and visualize your pipelines in Quix Cloud.</p>
+<p style="font-size: 1rem;">Quix is a complete platform for developing, deploying, and monitoring stream processing pipelines. You can build producer/consumer/transform apps with Quix Streams and Python, build and test pipelines with the Quix CLI, and then deploy, manage and observe the pipelines in Quix Cloud.</p>
+
+## Workflow summary
 
 Your Quix workflow:
 
-1. Develop your applications locally in Python with Quix Streams and the Quix CLI
-2. Test your pipeline locally with Quix CLI
-3. Deploy to Quix Cloud for scalability and observability
+1. Develop your applications locally in Python with Quix Streams, the Quix CLI, and your IDE of choice.
+2. Test and debug your pipeline locally with the Quix CLI and Docker.
+3. Deploy to Quix Cloud for scalability and observability.
 
 <div class="grid cards" markdown>
 

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -141,7 +141,7 @@
   </nav>
       <div class="header-btns">
         <button class="header-btn-inner github-btn" onclick="window.open('https://github.com/quixio/quix-streams', '_blank')">⭐️ Star us on GitHub</button>
-        <button class="header-btn-inner" onclick="window.open('https://quix.io/signup', '_blank')">Start for free</button>
+        <!--<button class="header-btn-inner" onclick="window.open('https://quix.io/signup', '_blank')">Start for free</button>-->
       </div>
   </div>
   </header>


### PR DESCRIPTION
## Description

Remove cloud-first option, as we want to promote command-line/local first approach.

- [x] remove cloud-first option box
- [x] remove "try for free" button 
- [x] update pitch text 

## Review

* [Page to review](link)
