### PR TITLE
Make Quix Streams 2.5 code sample work with public kafka

### DIFF
--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -33,7 +33,8 @@ import uuid
 # Connect to the public Quix hosted broker to consume data
 app = Application(
     broker_address="publickafka.quix.io:9092",  # Kafka broker address
-    consumer_group=str(uuid.uuid4())  # Kafka consumer group
+    consumer_group=str(uuid.uuid4()),  # Kafka consumer group
+    producer_extra_config={'enable.idempotence': False}
 )
 
 input_topic = app.topic("demo-onboarding-prod-chat", value_deserializer='json')


### PR DESCRIPTION
## Description

Modify getting started code so the Quix Streams 2.5+ code sample works with our public kafka install.

## Review

Test code sample against public kafka:

* [Page to review](link)
