### PR TITLE
Updates RunLLM widget url to point to new widget.runllm.com domain.

### DIFF
--- a/docs/javascripts/runllm-widget.js
+++ b/docs/javascripts/runllm-widget.js
@@ -3,8 +3,7 @@ document.addEventListener("DOMContentLoaded", function() {
     script.defer = true;
     script.type = 'module';
     script.id = 'runllm-widget-script';
-    script.src = 'https://cdn.jsdelivr.net/npm/@runllm/search-widget@stable/dist/run-llm-search-widget.es.js';
-    script.setAttribute('version', 'stable');
+    script.src = 'https://widget.runllm.com';
     script.setAttribute('runllm-preset', 'mkdocs');
     script.setAttribute('runllm-server-address', 'https://api.runllm.com');
     script.setAttribute('runllm-assistant-id', '111');


### PR DESCRIPTION
## Description

This PR updates the RunLLM widget url to use our new widget.runllm.com domain.

The version field has also been removed as it's no longer required with this update.

## Review

Widget should work the same, you should just now be getting the JS from a different place. 

If you'd like to test in a staging environment, comment with the URL and we can open up recaptcha authentication on that domain for the widget to work.