### PR TITLE
Fix the Install Quix Streams link on the Welcome page

### DIFF
--- a/docs/get-started/welcome.md
+++ b/docs/get-started/welcome.md
@@ -23,6 +23,6 @@ Your Quix workflow:
 
     Start building your stream processing pipeline locally on the command line with Quix Streams.
 
-    [Install Quix Streams :octicons-arrow-right-24:](./install.md)
+    [Install Quix Streams :octicons-arrow-right-24:](./quix-start.md)
 
 </div>


### PR DESCRIPTION
## Description

The Install Quix Streams link leads to a non-existent https://quix.io/docs/get-started/install.md and an ugly 404
This PR makes the link point to quix-start.md
