### PR TITLE
Fix warning coming from simple app run

### DIFF
--- a/docs/get-started/quix-start.md
+++ b/docs/get-started/quix-start.md
@@ -46,7 +46,7 @@ sdf = sdf[["role", "tokens_count"]]
 
 sdf = sdf.update(lambda row: print(row))
 
-app.run(sdf)
+app.run()
 ```
 
 Save the code in a file named `qs.py`.


### PR DESCRIPTION
Remove `sdf` argument from `app.run(sdf)` call in simple app code.